### PR TITLE
Fix truncated tweets

### DIFF
--- a/source/lambda/ingestion-producer/index.js
+++ b/source/lambda/ingestion-producer/index.js
@@ -38,6 +38,7 @@ exports.handler = async (event) => {
                     ...(process.env.LOCATION_GEOCODE !== undefined ? {geocode: process.env.LOCATION_GEOCODE}: undefined),
                     include_entities: true,
                     result_type: process.env.QUERY_RESULT_TYPE,
+                    tweet_mode: 'extended',
                     lang: languages[index]
                 };
                 console.debug(`Search API Params: ${JSON.stringify(twitSearchParams)}`);


### PR DESCRIPTION
A parameter `tweet_mode: "extended"` is needed to retrieve the full tweets and not a truncated version
https://developer.twitter.com/en/docs/twitter-ads-api/creatives/api-reference/tweets

Before this patch, the tweets retrieved and analysed are truncated (only the first part is included).
After this patch, the tweets are retrieved and analysed in their full length.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.